### PR TITLE
Add TOC to index for use on readthedocs

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,8 +12,18 @@ system defined types, interfaces, methods and constants that can be used in a Sl
 program.
 
 This reference groups the standard library declarations as:
-- [Interfaces](interfaces/): all builtin interfaces usable as generic constraints.
-- [Types](types/): all builtin types and their members, such as `StructuredBuffer`, `Texture2D` and etc.
-- [Global Declarations](global-decls/): all other constants and functions defined in the global scope.
+- [Interfaces](interfaces/index): all builtin interfaces usable as generic constraints.
+- [Types](types/index): all builtin types and their members, such as `StructuredBuffer`, `Texture2D` and etc.
+- [Global Declarations](global-decls/index): all other constants and functions defined in the global scope.
 
 This documentation is still a work-in-progress.
+
+```{toctree}
+:titlesonly:
+:hidden:
+
+Interfaces <interfaces/index>
+Types <types/index>
+Attributes <attributes/index>
+Global Declarations <global-decls/index>
+```


### PR DESCRIPTION
For https://github.com/shader-slang/stdlib-reference/issues/3

We don't generate the index.md for this repo, unlike the rest of the reference, so this change manually adds a readthedocs-friendly table of contents, which will allow for the TOCs of each group within to be linked together once those get generated.